### PR TITLE
Fix QGIS layer naming and URL parsing

### DIFF
--- a/src/eopfzarr_dataset.h
+++ b/src/eopfzarr_dataset.h
@@ -33,12 +33,15 @@ class EOPFZarrDataset : public GDALPamDataset
     ~EOPFZarrDataset();
 
     // Factory method
-    static EOPFZarrDataset* Create(GDALDataset* inner, GDALDriver* drv);
+    static EOPFZarrDataset* Create(GDALDataset* inner,
+                                   GDALDriver* drv,
+                                   const char* pszSubdatasetPath = nullptr);
 
     // Optimized metadata loading
     void LoadEOPFMetadata();
     void LoadGeospatialInfo() const;
     void ProcessCornerCoordinates() const;
+    void UpdateBandDescriptionsFromMetadata();
 
     char** GetFileList() override;
 

--- a/tests/integration/test_eopfzarr_integration.py
+++ b/tests/integration/test_eopfzarr_integration.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.require_driver("EOPFZARR")
 
 # Remote Zarr test data URLs (publicly accessible)
 REMOTE_SAMPLE_ZARR = "https://objects.eodc.eu/e05ab01a9d56408d82ac32d69a5aae2a:202506-s02msil1c/25/products/cpm_v256/S2C_MSIL1C_20250625T095051_N0511_R079_T33TWE_20250625T132854.zarr"
-REMOTE_WITH_SUBDATASETS_ZARR = "https://objects.eodc.eu/e05ab01a9d56408d82ac32d69a5aae2a:202507-s02msil2a/21/products/cpm_v256/S2B_MSIL2A_20250721T073619_N0511_R092_T36HUG_20250721T095416.zarr/measurements/reflectance/r60m/b01"
+REMOTE_WITH_SUBDATASETS_ZARR = "https://objects.eodc.eu/e05ab01a9d56408d82ac32d69a5aae2a:202506-s02msil1c/25/products/cpm_v256/S2C_MSIL1C_20250625T095051_N0511_R079_T33TWE_20250625T132854.zarr/measurements/reflectance/r60m/b01"
 
 
 

--- a/tests/integration/test_rasterio_eopfzarr_improved.py
+++ b/tests/integration/test_rasterio_eopfzarr_improved.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.require_driver("EOPFZARR")
 
 # Test URLs
 REMOTE_SAMPLE_ZARR = "https://objects.eodc.eu/e05ab01a9d56408d82ac32d69a5aae2a:202506-s02msil1c/25/products/cpm_v256/S2C_MSIL1C_20250625T095051_N0511_R079_T33TWE_20250625T132854.zarr"
-REMOTE_WITH_SUBDATASETS_ZARR = "https://objects.eodc.eu/e05ab01a9d56408d82ac32d69a5aae2a:202507-s02msil2a/21/products/cpm_v256/S2B_MSIL2A_20250721T073619_N0511_R092_T36HUG_20250721T095416.zarr/conditions/mask/detector_footprint/r10m/b04"
+REMOTE_WITH_SUBDATASETS_ZARR = "https://objects.eodc.eu/e05ab01a9d56408d82ac32d69a5aae2a:202506-s02msil1c/25/products/cpm_v256/S2C_MSIL1C_20250625T095051_N0511_R079_T33TWE_20250625T132854.zarr/measurements/reflectance/r60m/b01"
 
 
 # Environment Detection and Configuration


### PR DESCRIPTION
- Fixed ParseSubdatasetPath to handle URL/VSI paths correctly
- Added friendly band descriptions from subdataset path
- Both colon and path formats now produce identical results
- Subdataset descriptions use underscores instead of slashes