### PR TITLE
Add Apple Silicon (arm64) support to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-latest, macos-13]
+        os: [ubuntu-24.04, windows-latest, macos-13, macos-14]
+        include:
+          - os: macos-13
+            arch: x86_64
+          - os: macos-14
+            arch: arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -364,15 +369,29 @@ jobs:
           gdalinfo --formats | findstr "EOPFZARR"
 
       # Upload Artifacts
-      - name: Upload Build Artifact
+      - name: Upload Build Artifact (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/upload-artifact@v4
+        with:
+          name: gdal_EOPFZarr-${{ runner.os }}-${{ matrix.arch }}
+          path: build/gdal_EOPFZarr.dylib
+          if-no-files-found: error
+
+      - name: Upload Build Artifact (Linux)
+        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
           name: gdal_EOPFZarr-${{ runner.os }}
-          path: |
-            build/gdal_EOPFZarr.so
-            build/gdal_EOPFZarr.dylib
-            build/Release/gdal_EOPFZarr.dll
-          if-no-files-found: ignore
+          path: build/gdal_EOPFZarr.so
+          if-no-files-found: error
+
+      - name: Upload Build Artifact (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: gdal_EOPFZarr-${{ runner.os }}
+          path: build/Release/gdal_EOPFZarr.dll
+          if-no-files-found: error
 
   package-release:
     name: Package Release Artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Apple Silicon (arm64) support in GitHub Actions CI/CD pipeline
+- Separate build artifacts for macOS Intel (x86_64) and Apple Silicon (arm64)
+- Architecture-specific artifact naming: `gdal_EOPFZarr-macOS-x86_64` and `gdal_EOPFZarr-macOS-arm64`
+
+### Changed
+
+- GitHub Actions now builds on both `macos-13` (Intel) and `macos-14` (Apple Silicon)
+- Improved artifact upload specificity with platform-specific steps
+- Enhanced error detection with `if-no-files-found: error` for all artifacts
+
 ### Planning
 
 - Future enhancements and improvements


### PR DESCRIPTION
## Summary
This PR adds native Apple Silicon (arm64) support to the GitHub Actions CI/CD pipeline.

## Problem
The current workflow only builds on `macos-13` (Intel x86_64), making artifacts incompatible with Apple Silicon Macs (M1/M2/M3). Users downloading artifacts from GitHub Actions cannot use them on their Apple Silicon machines.

## Solution
- ✅ Added `macos-14` runner for native Apple Silicon builds
- ✅ Build separate artifacts for both architectures:
  - `gdal_EOPFZarr-macOS-x86_64` (Intel)
  - `gdal_EOPFZarr-macOS-arm64` (Apple Silicon)
- ✅ Improved artifact upload with platform-specific steps
- ✅ Enhanced error detection with `if-no-files-found: error`

## Testing
- Local build on Apple Silicon Mac successful
- Plugin verified as `Mach-O 64-bit bundle arm64`
- GDAL successfully recognizes the EOPFZARR driver

## Benefits
- Native performance on Apple Silicon Macs
- Compatibility with both Intel and ARM architectures
- Better user experience for M-series Mac users
- Addresses issue with incompatible GitHub Actions artifacts

## Related
Fixes the compatibility issue where GitHub Actions artifacts don't work on Apple Silicon Macs.