### PR TITLE
feat: Extract EOPF product metadata from Zarr groups (#154)

### DIFF
--- a/src/eopf_metadata.cpp
+++ b/src/eopf_metadata.cpp
@@ -881,6 +881,138 @@ void EOPF::DiscoverSubdatasets(GDALDataset& ds,
     GDALClose(poZarrDS);
 }
 
+/* ------------------------------------------------------------------ */
+/*      Extract product-level metadata from STAC discovery             */
+/* ------------------------------------------------------------------ */
+static void ExtractProductMetadata(const CPLJSONObject& obj, GDALDataset& ds)
+{
+    // Extract title from other_metadata
+    const CPLJSONObject& otherMeta = obj.GetObj("other_metadata");
+    if (otherMeta.IsValid())
+    {
+        std::string title = otherMeta.GetString("title", "");
+        if (!title.empty())
+        {
+            ds.SetMetadataItem("EOPF_TITLE", title.c_str(), "EOPF");
+        }
+    }
+
+    // Extract properties from stac_discovery
+    const CPLJSONObject& stacDiscovery = obj.GetObj("stac_discovery");
+    if (!stacDiscovery.IsValid())
+        return;
+
+    const CPLJSONObject& properties = stacDiscovery.GetObj("properties");
+    if (!properties.IsValid())
+        return;
+
+    CPLDebug("EOPFZARR", "Extracting product metadata from STAC properties");
+
+    // Helper: set string metadata item if present
+    auto setStr = [&](const char* stacKey, const char* eopfKey)
+    {
+        std::string val = properties.GetString(stacKey, "");
+        if (!val.empty())
+        {
+            ds.SetMetadataItem(eopfKey, val.c_str(), "EOPF");
+        }
+    };
+
+    // Helper: set integer metadata item if present
+    auto setInt = [&](const char* stacKey, const char* eopfKey)
+    {
+        int val = properties.GetInteger(stacKey, 0);
+        if (val != 0)
+        {
+            ds.SetMetadataItem(eopfKey, CPLString().Printf("%d", val).c_str(), "EOPF");
+        }
+    };
+
+    // Helper: set double metadata item if present
+    auto setDouble = [&](const char* stacKey, const char* eopfKey)
+    {
+        double val = properties.GetDouble(stacKey, -1.0);
+        if (val >= 0.0)
+        {
+            ds.SetMetadataItem(eopfKey, CPLString().Printf("%.6f", val).c_str(), "EOPF");
+        }
+    };
+
+    // Helper: set string array as comma-separated
+    auto setStrArray = [&](const char* stacKey, const char* eopfKey)
+    {
+        const CPLJSONArray arr = properties.GetArray(stacKey);
+        if (arr.IsValid() && arr.Size() > 0)
+        {
+            std::string joined;
+            for (int i = 0; i < arr.Size(); i++)
+            {
+                if (i > 0)
+                    joined += ",";
+                joined += arr[i].ToString();
+            }
+            ds.SetMetadataItem(eopfKey, joined.c_str(), "EOPF");
+        }
+    };
+
+    // Common metadata
+    setStr("constellation", "EOPF_CONSTELLATION");
+    setStr("platform", "EOPF_PLATFORM");
+    setStrArray("instruments", "EOPF_INSTRUMENTS");
+    setStr("datetime", "EOPF_DATETIME");
+    setStr("start_datetime", "EOPF_START_DATETIME");
+    setStr("end_datetime", "EOPF_END_DATETIME");
+    setStr("created", "EOPF_CREATED");
+
+    // Product info
+    setStr("product:type", "EOPF_PRODUCT_TYPE");
+    setStr("product:timeliness", "EOPF_TIMELINESS");
+    setStr("product:timeliness_category", "EOPF_TIMELINESS_CATEGORY");
+
+    // Processing info
+    setStr("processing:level", "EOPF_PROCESSING_LEVEL");
+    setStr("processing:lineage", "EOPF_PROCESSING_LINEAGE");
+
+    // EOPF-specific
+    setStr("eopf:datatake_id", "EOPF_DATATAKE_ID");
+    setStr("eopf:instrument_mode", "EOPF_INSTRUMENT_MODE");
+
+    // Satellite orbit info
+    setInt("sat:absolute_orbit", "EOPF_ABSOLUTE_ORBIT");
+    setInt("sat:relative_orbit", "EOPF_RELATIVE_ORBIT");
+    setStr("sat:orbit_state", "EOPF_ORBIT_STATE");
+    setStr("sat:platform_international_designator", "EOPF_INTL_DESIGNATOR");
+
+    // SAR-specific (Sentinel-1)
+    setStr("sar:frequency_band", "EOPF_SAR_FREQUENCY_BAND");
+    setStr("sar:instrument_mode", "EOPF_SAR_INSTRUMENT_MODE");
+    setStrArray("sar:polarizations", "EOPF_SAR_POLARIZATIONS");
+    setStr("sar:product_type", "EOPF_SAR_PRODUCT_TYPE");
+
+    // Optical-specific (Sentinel-2)
+    setDouble("eo:cloud_cover", "EOPF_CLOUD_COVER");
+    setDouble("eo:snow_cover", "EOPF_SNOW_COVER");
+    setStr("gsd", "EOPF_GSD");
+}
+
+void EOPF::AttachProductMetadata(GDALDataset& ds, const std::string& rootPath)
+{
+    CPLJSONDocument doc;
+
+    if (LoadZMetadata(rootPath, doc))
+    {
+        ExtractProductMetadata(doc.GetRoot(), ds);
+    }
+    else
+    {
+        std::string zattrsPath = CPLFormFilename(rootPath.c_str(), ".zattrs", nullptr);
+        if (doc.Load(zattrsPath))
+        {
+            ExtractProductMetadata(doc.GetRoot(), ds);
+        }
+    }
+}
+
 void EOPF::AttachMetadata(GDALDataset& ds, const std::string& rootPath)
 {
     CPLJSONDocument doc;
@@ -915,6 +1047,7 @@ void EOPF::AttachMetadata(GDALDataset& ds, const std::string& rootPath)
     {
         const CPLJSONObject& root = doc.GetRoot();  // This is .zattrs content now
         ExtractCoordinateMetadata(root, ds);
+        ExtractProductMetadata(root, ds);
     }
     else
     {

--- a/src/eopf_metadata.h
+++ b/src/eopf_metadata.h
@@ -8,6 +8,7 @@
 namespace EOPF
 {
 void AttachMetadata(GDALDataset& ds, const std::string& rootPath);
+void AttachProductMetadata(GDALDataset& ds, const std::string& rootPath);
 void DiscoverSubdatasets(GDALDataset& ds,
                          const std::string& rootPath,
                          const CPLJSONObject& metadata);

--- a/src/eopfzarr_driver.cpp
+++ b/src/eopfzarr_driver.cpp
@@ -864,6 +864,7 @@ static GDALDataset* EOPFOpen(GDALOpenInfo* poOpenInfo)
                 if (poMultiDS)
                 {
                     poMultiDS->SetMetadataItem("EOPFZARR_WRAPPER", "YES", "EOPF");
+                    EOPF::AttachProductMetadata(*poMultiDS, mainPath);
                     return poMultiDS;
                 }
                 else
@@ -1013,6 +1014,7 @@ static GDALDataset* EOPFOpen(GDALOpenInfo* poOpenInfo)
                     poBurstWrapper->SetMetadataItem(
                         "EOPF_BURST_INDEX",
                         CPLString().Printf("%d", pFoundBurst->burstIndex).c_str());
+                    EOPF::AttachProductMetadata(*poBurstWrapper, mainPath);
                     return poBurstWrapper;
                 }
                 else

--- a/tests/integration/test_metadata_extraction.py
+++ b/tests/integration/test_metadata_extraction.py
@@ -1,0 +1,248 @@
+"""
+Integration tests for EOPF metadata extraction from Zarr groups.
+
+Tests that STAC discovery properties and other_metadata are extracted
+and exposed via the EOPF metadata domain.
+"""
+import pytest
+from osgeo import gdal
+
+# Test URLs
+SLC_URL = (
+    "/vsicurl/https://objects.eodc.eu/e05ab01a9d56408d82ac32d69a5aae2a:"
+    "notebook-data/tutorial_data/cpm_v262/"
+    "S1C_IW_SLC__1SDV_20251016T165627_20251016T165654_004590_00913B_30C4.zarr"
+)
+
+GRD_URL = (
+    "/vsicurl/https://objects.eodc.eu/e05ab01a9d56408d82ac32d69a5aae2a:"
+    "202602-s01siwgrh-global/05/products/cpm_v262/"
+    "S1C_IW_GRDH_1SDV_20260205T120122_20260205T120158_006220_00C7E4_5D6E.zarr"
+)
+
+S2_URL = (
+    "/vsicurl/https://objects.eodc.eu/e05ab01a9d56408d82ac32d69a5aae2a:"
+    "202602-s02msil1c-eu/03/products/cpm_v262/"
+    "S2A_MSIL1C_20260203T092011_N0511_R050_T35SLB_20260203T111324.zarr"
+)
+
+
+class TestSentinel1SLCMetadata:
+    """Tests for Sentinel-1 SLC product metadata extraction."""
+
+    @pytest.fixture
+    def dataset(self):
+        """Open SLC product."""
+        gdal.UseExceptions()
+        ds = gdal.Open(f"EOPFZARR:'{SLC_URL}'")
+        yield ds
+        if ds:
+            ds = None
+
+    def test_constellation(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_CONSTELLATION", "EOPF") == "sentinel-1"
+
+    def test_platform(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_PLATFORM", "EOPF") == "sentinel-1c"
+
+    def test_orbit_state(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_ORBIT_STATE", "EOPF") == "ascending"
+
+    def test_absolute_orbit(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_ABSOLUTE_ORBIT", "EOPF") == "4590"
+
+    def test_relative_orbit(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_RELATIVE_ORBIT", "EOPF") == "44"
+
+    def test_instrument_mode(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_INSTRUMENT_MODE", "EOPF") == "IW"
+
+    def test_datetime(self, dataset):
+        assert dataset is not None
+        dt = dataset.GetMetadataItem("EOPF_DATETIME", "EOPF")
+        assert dt is not None
+        assert "2025-10-16" in dt
+
+    def test_start_datetime(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_START_DATETIME", "EOPF") is not None
+
+    def test_end_datetime(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_END_DATETIME", "EOPF") is not None
+
+    def test_sar_polarizations(self, dataset):
+        assert dataset is not None
+        pols = dataset.GetMetadataItem("EOPF_SAR_POLARIZATIONS", "EOPF")
+        assert pols is not None
+        assert "VV" in pols
+        assert "VH" in pols
+
+    def test_sar_frequency_band(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_SAR_FREQUENCY_BAND", "EOPF") == "C"
+
+    def test_sar_instrument_mode(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_SAR_INSTRUMENT_MODE", "EOPF") == "IW"
+
+    def test_product_type(self, dataset):
+        assert dataset is not None
+        pt = dataset.GetMetadataItem("EOPF_PRODUCT_TYPE", "EOPF")
+        assert pt is not None
+        assert "SLC" in pt
+
+    def test_title(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_TITLE", "EOPF") == "S01SIWSLC"
+
+    def test_datatake_id(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_DATATAKE_ID", "EOPF") is not None
+
+    def test_instruments(self, dataset):
+        assert dataset is not None
+        inst = dataset.GetMetadataItem("EOPF_INSTRUMENTS", "EOPF")
+        assert inst is not None
+        assert "sar" in inst
+
+
+class TestSentinel1GRDMetadata:
+    """Tests for Sentinel-1 GRD product metadata extraction."""
+
+    @pytest.fixture
+    def dataset(self):
+        """Open GRD product."""
+        gdal.UseExceptions()
+        ds = gdal.Open(f"EOPFZARR:'{GRD_URL}'")
+        yield ds
+        if ds:
+            ds = None
+
+    def test_constellation(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_CONSTELLATION", "EOPF") == "sentinel-1"
+
+    def test_orbit_state(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_ORBIT_STATE", "EOPF") == "descending"
+
+    def test_sar_product_type(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_SAR_PRODUCT_TYPE", "EOPF") == "GRD"
+
+    def test_title(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_TITLE", "EOPF") == "S01SIWGRD"
+
+    def test_timeliness(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_TIMELINESS", "EOPF") is not None
+
+    def test_processing_lineage(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_PROCESSING_LINEAGE", "EOPF") == "systematic"
+
+
+class TestSentinel2Metadata:
+    """Tests for Sentinel-2 product metadata extraction."""
+
+    @pytest.fixture
+    def dataset(self):
+        """Open Sentinel-2 product."""
+        gdal.UseExceptions()
+        ds = gdal.Open(f"EOPFZARR:'{S2_URL}'")
+        yield ds
+        if ds:
+            ds = None
+
+    def test_constellation(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_CONSTELLATION", "EOPF") == "sentinel-2"
+
+    def test_platform(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_PLATFORM", "EOPF") == "sentinel-2a"
+
+    def test_cloud_cover(self, dataset):
+        assert dataset is not None
+        cc = dataset.GetMetadataItem("EOPF_CLOUD_COVER", "EOPF")
+        assert cc is not None
+        assert float(cc) >= 0.0
+
+    def test_snow_cover(self, dataset):
+        assert dataset is not None
+        sc = dataset.GetMetadataItem("EOPF_SNOW_COVER", "EOPF")
+        assert sc is not None
+        assert float(sc) >= 0.0
+
+    def test_processing_level(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_PROCESSING_LEVEL", "EOPF") == "L1C"
+
+    def test_gsd(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_GSD", "EOPF") == "10"
+
+    def test_orbit_state(self, dataset):
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_ORBIT_STATE", "EOPF") == "descending"
+
+    def test_instruments(self, dataset):
+        assert dataset is not None
+        inst = dataset.GetMetadataItem("EOPF_INSTRUMENTS", "EOPF")
+        assert inst is not None
+        assert "msi" in inst
+
+    def test_product_type(self, dataset):
+        assert dataset is not None
+        pt = dataset.GetMetadataItem("EOPF_PRODUCT_TYPE", "EOPF")
+        assert pt is not None
+        assert "L1C" in pt
+
+    def test_title(self, dataset):
+        """Sentinel-2 other_metadata has detailed info, not simple title."""
+        assert dataset is not None
+        # S2 other_metadata may not have a simple 'title' field
+        # (it has band_description, geometric_refinement, etc. instead)
+        # This is OK - title is optional
+
+
+class TestMetadataDomainIsolation:
+    """Tests that EOPF metadata is in the EOPF domain, not default domain."""
+
+    @pytest.fixture
+    def dataset(self):
+        """Open GRD product."""
+        gdal.UseExceptions()
+        ds = gdal.Open(f"EOPFZARR:'{GRD_URL}'")
+        yield ds
+        if ds:
+            ds = None
+
+    def test_eopf_domain_has_items(self, dataset):
+        """EOPF domain should contain metadata items."""
+        assert dataset is not None
+        md = dataset.GetMetadata("EOPF")
+        assert md is not None
+        assert len(md) > 0
+
+    def test_constellation_in_eopf_domain(self, dataset):
+        """EOPF_CONSTELLATION should be in EOPF domain."""
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_CONSTELLATION", "EOPF") is not None
+
+    def test_constellation_not_in_default_domain(self, dataset):
+        """EOPF_CONSTELLATION should NOT be in default domain."""
+        assert dataset is not None
+        assert dataset.GetMetadataItem("EOPF_CONSTELLATION") is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Parses `stac_discovery.properties` and `other_metadata` from root `.zattrs` and exposes 26 metadata keys via the `EOPF` metadata domain
- Supports all product types: Sentinel-1 SLC/GRD (orbit, SAR params, polarizations) and Sentinel-2 (cloud/snow cover, GSD, processing level)
- Metadata also attached to GRD multi-band and SLC burst wrapper datasets
- Accessible via `ds.GetMetadataItem("EOPF_ORBIT_STATE", "EOPF")` or `gdalinfo` EOPF domain

## Metadata Keys
Common: `EOPF_CONSTELLATION`, `EOPF_PLATFORM`, `EOPF_DATETIME`, `EOPF_ORBIT_STATE`, `EOPF_ABSOLUTE_ORBIT`, `EOPF_RELATIVE_ORBIT`, `EOPF_PRODUCT_TYPE`, `EOPF_INSTRUMENT_MODE`, etc.

SAR-specific: `EOPF_SAR_POLARIZATIONS`, `EOPF_SAR_FREQUENCY_BAND`, `EOPF_SAR_PRODUCT_TYPE`

Optical-specific: `EOPF_CLOUD_COVER`, `EOPF_SNOW_COVER`, `EOPF_GSD`, `EOPF_PROCESSING_LEVEL`

## Test plan
- [x] 35 new integration tests pass (SLC, GRD, S2 products + domain isolation)
- [x] 50 existing tests pass (coordinate detection, GRD multiband, SLC burst)
- [x] Build and clang-format clean

Closes #154