### PR TITLE
feat: Extract GCPs from conditions/gcp/ arrays (#156)

### DIFF
--- a/src/eopfzarr_dataset.cpp
+++ b/src/eopfzarr_dataset.cpp
@@ -76,6 +76,13 @@ EOPFZarrDataset::~EOPFZarrDataset()
         CSLDestroy(m_papszDefaultDomainFilteredMetadata);
         m_papszDefaultDomainFilteredMetadata = nullptr;
     }
+
+    // Free GCP strings
+    for (auto& gcp : mGCPs)
+    {
+        CPLFree(gcp.pszId);
+        CPLFree(gcp.pszInfo);
+    }
 }
 
 static std::string ExtractRootPath(const std::string& description)
@@ -809,17 +816,257 @@ int EOPFZarrDataset::CloseDependentDatasets()
 
 int EOPFZarrDataset::GetGCPCount()
 {
+    LoadGCPs();
+    if (!mGCPs.empty())
+        return static_cast<int>(mGCPs.size());
     return mInner->GetGCPCount();
 }
 
 const OGRSpatialReference* EOPFZarrDataset::GetGCPSpatialRef() const
 {
+    const_cast<EOPFZarrDataset*>(this)->LoadGCPs();
+    if (!mGCPs.empty())
+        return &mGCPSRS;
     return mInner->GetGCPSpatialRef();
 }
 
 const GDAL_GCP* EOPFZarrDataset::GetGCPs()
 {
+    LoadGCPs();
+    if (!mGCPs.empty())
+        return mGCPs.data();
     return mInner->GetGCPs();
+}
+
+void EOPFZarrDataset::LoadGCPs()
+{
+    if (mGCPsLoaded)
+        return;
+    mGCPsLoaded = true;
+
+    // GCPs only make sense for measurement subdatasets
+    const char* pszSubPath = GetMetadataItem("SUBDATASET_PATH");
+    if (!pszSubPath || strlen(pszSubPath) == 0)
+    {
+        CPLDebug("EOPFZARR", "LoadGCPs: No SUBDATASET_PATH — skipping");
+        return;
+    }
+
+    std::string subPath(pszSubPath);
+    std::string description = mInner->GetDescription();
+    std::string rootPath = ExtractRootPath(description);
+
+    // Navigate up to the product group containing conditions/gcp/
+    // From "S01SIWGRD_.../measurements/grd" we go up past "measurements/grd"
+    // From "S01SIWSLC_.../measurements/slc" we go up past "measurements/slc"
+    std::string parentGroup = subPath;
+
+    // Remove leading slash
+    if (!parentGroup.empty() && parentGroup[0] == '/')
+        parentGroup = parentGroup.substr(1);
+
+    // Go up two levels (past measurements/<type>)
+    for (int level = 0; level < 2; level++)
+    {
+        size_t lastSlash = parentGroup.find_last_of('/');
+        if (lastSlash == std::string::npos)
+        {
+            CPLDebug("EOPFZARR", "LoadGCPs: Cannot navigate up from %s", parentGroup.c_str());
+            return;
+        }
+        parentGroup = parentGroup.substr(0, lastSlash);
+    }
+
+    CPLDebug("EOPFZARR", "LoadGCPs: Parent group = %s", parentGroup.c_str());
+
+    // Construct Zarr paths for GCP arrays
+    const char* arrayNames[] = {"pixel", "line", "latitude", "longitude", "height"};
+    GDALDataset* gcpDS[5] = {nullptr};
+
+    for (int i = 0; i < 5; i++)
+    {
+        std::string zarrPath =
+            "ZARR:\"" + rootPath + "\":/" + parentGroup + "/conditions/gcp/" + arrayNames[i];
+        gcpDS[i] = GDALDataset::FromHandle(GDALOpenEx(
+            zarrPath.c_str(), GDAL_OF_RASTER | GDAL_OF_READONLY, nullptr, nullptr, nullptr));
+        if (!gcpDS[i])
+        {
+            CPLDebug("EOPFZARR",
+                     "LoadGCPs: Failed to open %s array: %s",
+                     arrayNames[i],
+                     zarrPath.c_str());
+            // Clean up already opened
+            for (int j = 0; j < i; j++)
+                GDALClose(gcpDS[j]);
+            return;
+        }
+    }
+
+    GDALDataset* pixelDS = gcpDS[0];
+    GDALDataset* lineDS = gcpDS[1];
+    GDALDataset* latDS = gcpDS[2];
+    GDALDataset* lonDS = gcpDS[3];
+    GDALDataset* heightDS = gcpDS[4];
+
+    // pixel and line are 1D arrays
+    int nPixels = std::max(pixelDS->GetRasterXSize(), pixelDS->GetRasterYSize());
+    int nLines = std::max(lineDS->GetRasterXSize(), lineDS->GetRasterYSize());
+
+    // lat, lon, height are 2D arrays [nLines x nPixels]
+    int latHeight = latDS->GetRasterYSize();
+    int latWidth = latDS->GetRasterXSize();
+
+    CPLDebug("EOPFZARR",
+             "LoadGCPs: pixel count=%d, line count=%d, lat dims=%dx%d",
+             nPixels,
+             nLines,
+             latWidth,
+             latHeight);
+
+    // Validate dimensions match
+    if (latHeight != nLines || latWidth != nPixels)
+    {
+        CPLDebug("EOPFZARR",
+                 "LoadGCPs: Dimension mismatch — lat(%dx%d) vs pixel(%d) x line(%d)",
+                 latWidth,
+                 latHeight,
+                 nPixels,
+                 nLines);
+        for (int i = 0; i < 5; i++)
+            GDALClose(gcpDS[i]);
+        return;
+    }
+
+    // Read 1D pixel array
+    std::vector<double> pixelVals(nPixels);
+    GDALRasterBand* pixelBand = pixelDS->GetRasterBand(1);
+    CPLErr err;
+    if (pixelDS->GetRasterXSize() >= nPixels)
+        err = pixelBand->RasterIO(
+            GF_Read, 0, 0, nPixels, 1, pixelVals.data(), nPixels, 1, GDT_Float64, 0, 0, nullptr);
+    else
+        err = pixelBand->RasterIO(
+            GF_Read, 0, 0, 1, nPixels, pixelVals.data(), 1, nPixels, GDT_Float64, 0, 0, nullptr);
+    if (err != CE_None)
+    {
+        CPLDebug("EOPFZARR", "LoadGCPs: Failed to read pixel array");
+        for (int i = 0; i < 5; i++)
+            GDALClose(gcpDS[i]);
+        return;
+    }
+
+    // Read 1D line array
+    std::vector<double> lineVals(nLines);
+    GDALRasterBand* lineBand = lineDS->GetRasterBand(1);
+    if (lineDS->GetRasterXSize() >= nLines)
+        err = lineBand->RasterIO(
+            GF_Read, 0, 0, nLines, 1, lineVals.data(), nLines, 1, GDT_Float64, 0, 0, nullptr);
+    else
+        err = lineBand->RasterIO(
+            GF_Read, 0, 0, 1, nLines, lineVals.data(), 1, nLines, GDT_Float64, 0, 0, nullptr);
+    if (err != CE_None)
+    {
+        CPLDebug("EOPFZARR", "LoadGCPs: Failed to read line array");
+        for (int i = 0; i < 5; i++)
+            GDALClose(gcpDS[i]);
+        return;
+    }
+
+    // Read 2D latitude array [nLines x nPixels]
+    std::vector<double> latVals(nLines * nPixels);
+    err = latDS->GetRasterBand(1)->RasterIO(GF_Read,
+                                            0,
+                                            0,
+                                            latWidth,
+                                            latHeight,
+                                            latVals.data(),
+                                            latWidth,
+                                            latHeight,
+                                            GDT_Float64,
+                                            0,
+                                            0,
+                                            nullptr);
+    if (err != CE_None)
+    {
+        CPLDebug("EOPFZARR", "LoadGCPs: Failed to read latitude array");
+        for (int i = 0; i < 5; i++)
+            GDALClose(gcpDS[i]);
+        return;
+    }
+
+    // Read 2D longitude array [nLines x nPixels]
+    std::vector<double> lonVals(nLines * nPixels);
+    err = lonDS->GetRasterBand(1)->RasterIO(GF_Read,
+                                            0,
+                                            0,
+                                            latWidth,
+                                            latHeight,
+                                            lonVals.data(),
+                                            latWidth,
+                                            latHeight,
+                                            GDT_Float64,
+                                            0,
+                                            0,
+                                            nullptr);
+    if (err != CE_None)
+    {
+        CPLDebug("EOPFZARR", "LoadGCPs: Failed to read longitude array");
+        for (int i = 0; i < 5; i++)
+            GDALClose(gcpDS[i]);
+        return;
+    }
+
+    // Read 2D height array [nLines x nPixels]
+    std::vector<double> heightVals(nLines * nPixels);
+    err = heightDS->GetRasterBand(1)->RasterIO(GF_Read,
+                                               0,
+                                               0,
+                                               latWidth,
+                                               latHeight,
+                                               heightVals.data(),
+                                               latWidth,
+                                               latHeight,
+                                               GDT_Float64,
+                                               0,
+                                               0,
+                                               nullptr);
+    if (err != CE_None)
+    {
+        CPLDebug("EOPFZARR", "LoadGCPs: Failed to read height array — using 0");
+        std::fill(heightVals.begin(), heightVals.end(), 0.0);
+    }
+
+    // Close intermediate datasets
+    for (int i = 0; i < 5; i++)
+        GDALClose(gcpDS[i]);
+
+    // Build GDAL_GCP structures
+    mGCPs.resize(nLines * nPixels);
+    int gcpIdx = 0;
+    for (int iLine = 0; iLine < nLines; iLine++)
+    {
+        for (int iPixel = 0; iPixel < nPixels; iPixel++)
+        {
+            GDAL_GCP& gcp = mGCPs[gcpIdx];
+            char szId[32];
+            snprintf(szId, sizeof(szId), "GCP_%d", gcpIdx + 1);
+            gcp.pszId = CPLStrdup(szId);
+            gcp.pszInfo = CPLStrdup("");
+            gcp.dfGCPPixel = pixelVals[iPixel] + 0.5;
+            gcp.dfGCPLine = lineVals[iLine] + 0.5;
+            gcp.dfGCPX = lonVals[iLine * nPixels + iPixel];
+            gcp.dfGCPY = latVals[iLine * nPixels + iPixel];
+            gcp.dfGCPZ = heightVals[iLine * nPixels + iPixel];
+            gcpIdx++;
+        }
+    }
+
+    // Set GCP SRS to WGS84
+    mGCPSRS.SetWellKnownGeogCS("WGS84");
+    mGCPSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+
+    CPLDebug(
+        "EOPFZARR", "LoadGCPs: Loaded %d GCPs (%d lines x %d pixels)", gcpIdx, nLines, nPixels);
 }
 
 CPLErr EOPFZarrDataset::TryLoadXML(char** papszSiblingFiles)

--- a/src/eopfzarr_dataset.h
+++ b/src/eopfzarr_dataset.h
@@ -29,6 +29,12 @@ class EOPFZarrDataset : public GDALPamDataset
     mutable bool mMetadataLoaded;
     mutable bool mGeospatialInfoProcessed;
 
+    // GCP storage
+    std::vector<GDAL_GCP> mGCPs;
+    OGRSpatialReference mGCPSRS;
+    bool mGCPsLoaded = false;
+    void LoadGCPs();
+
   public:
     EOPFZarrDataset(std::unique_ptr<GDALDataset> inner, GDALDriver* selfDrv);
     ~EOPFZarrDataset();

--- a/tests/integration/test_gcp_extraction.py
+++ b/tests/integration/test_gcp_extraction.py
@@ -1,0 +1,219 @@
+"""
+Integration tests for GCP extraction from EOPF Zarr products.
+
+Tests that Ground Control Points are correctly extracted from
+conditions/gcp/ arrays in Sentinel-1 GRD and SLC products.
+"""
+import pytest
+from osgeo import gdal, osr
+
+# GRD product URL (has conditions/gcp/ arrays)
+GRD_URL = (
+    "/vsicurl/https://objects.eodc.eu/e05ab01a9d56408d82ac32d69a5aae2a:"
+    "202602-s01siwgrh-global/05/products/cpm_v262/"
+    "S1C_IW_GRDH_1SDV_20260205T120122_20260205T120158_006220_00C7E4_5D6E.zarr"
+)
+
+# SLC product URL
+SLC_URL = (
+    "/vsicurl/https://objects.eodc.eu/e05ab01a9d56408d82ac32d69a5aae2a:"
+    "notebook-data/tutorial_data/cpm_v262/"
+    "S1C_IW_SLC__1SDV_20251016T165627_20251016T165654_004590_00913B_30C4.zarr"
+)
+
+
+class TestGRDSubdatasetGCPs:
+    """Tests for GCP extraction from a GRD measurement subdataset."""
+
+    @pytest.fixture
+    def dataset(self):
+        """Open a GRD VV measurement subdataset."""
+        gdal.UseExceptions()
+        # Open root with GRD_MULTIBAND=NO to get subdataset listing
+        root = gdal.OpenEx(
+            f"EOPFZARR:'{GRD_URL}'",
+            gdal.OF_RASTER | gdal.OF_READONLY,
+            open_options=["GRD_MULTIBAND=NO"],
+        )
+        assert root is not None
+        subdatasets = root.GetMetadata("SUBDATASETS")
+        assert subdatasets is not None, "No SUBDATASETS metadata"
+        # Find the first measurement/grd subdataset
+        subds_name = None
+        for k, v in subdatasets.items():
+            if "_NAME" in k and "measurements/grd" in v:
+                subds_name = v
+                break
+        root = None
+        assert subds_name is not None, "No GRD measurement subdataset found"
+
+        ds = gdal.Open(subds_name)
+        yield ds
+        if ds:
+            ds = None
+
+    def test_gcp_count(self, dataset):
+        """GRD subdataset should have GCPs (expect ~294 = 14x21)."""
+        assert dataset is not None
+        count = dataset.GetGCPCount()
+        assert count > 0
+        assert count >= 100  # At least 100 GCPs expected
+
+    def test_gcp_coordinates_valid(self, dataset):
+        """GCPs should have valid lat/lon ranges."""
+        assert dataset is not None
+        gcps = dataset.GetGCPs()
+        assert gcps is not None
+        assert len(gcps) > 0
+        for gcp in gcps:
+            assert -180.0 <= gcp.GCPX <= 180.0, f"Longitude out of range: {gcp.GCPX}"
+            assert -90.0 <= gcp.GCPY <= 90.0, f"Latitude out of range: {gcp.GCPY}"
+
+    def test_gcp_pixel_line_valid(self, dataset):
+        """GCP pixel/line values should be within raster dimensions."""
+        assert dataset is not None
+        gcps = dataset.GetGCPs()
+        assert gcps is not None
+        width = dataset.RasterXSize
+        height = dataset.RasterYSize
+        for gcp in gcps:
+            assert -0.5 <= gcp.GCPPixel <= width + 0.5, (
+                f"GCP pixel {gcp.GCPPixel} outside raster width {width}"
+            )
+            assert -0.5 <= gcp.GCPLine <= height + 0.5, (
+                f"GCP line {gcp.GCPLine} outside raster height {height}"
+            )
+
+    def test_gcp_projection_wgs84(self, dataset):
+        """GCP SRS should be WGS84."""
+        assert dataset is not None
+        srs = dataset.GetGCPSpatialRef()
+        assert srs is not None
+        assert srs.IsGeographic()
+        # Check it's WGS84
+        authority = srs.GetAuthorityCode("DATUM")
+        assert authority == "6326", f"Expected WGS84 datum (6326), got {authority}"
+
+    def test_gcp_has_height(self, dataset):
+        """At least some GCPs should have non-zero height."""
+        assert dataset is not None
+        gcps = dataset.GetGCPs()
+        assert gcps is not None
+        # At least some GCPs should have height data
+        heights = [gcp.GCPZ for gcp in gcps]
+        # Heights can be 0 for sea-level; just check they're reasonable
+        for h in heights:
+            assert -500.0 <= h <= 10000.0, f"Height out of range: {h}"
+
+    def test_gcp_ids(self, dataset):
+        """Each GCP should have a unique ID."""
+        assert dataset is not None
+        gcps = dataset.GetGCPs()
+        assert gcps is not None
+        ids = [gcp.Id for gcp in gcps]
+        assert len(ids) == len(set(ids)), "GCP IDs are not unique"
+        assert all(gcp_id.startswith("GCP_") for gcp_id in ids)
+
+    def test_gcp_grid_structure(self, dataset):
+        """GCPs should form a regular grid pattern."""
+        assert dataset is not None
+        gcps = dataset.GetGCPs()
+        assert gcps is not None
+
+        # Extract unique pixel and line values
+        pixels = sorted(set(gcp.GCPPixel for gcp in gcps))
+        lines = sorted(set(gcp.GCPLine for gcp in gcps))
+
+        # Should have multiple unique values in each dimension
+        assert len(pixels) > 1, "GCPs should span multiple pixel columns"
+        assert len(lines) > 1, "GCPs should span multiple line rows"
+
+        # Total should be pixels * lines (rectangular grid)
+        assert len(gcps) == len(pixels) * len(lines), (
+            f"GCP count {len(gcps)} != {len(pixels)} x {len(lines)}"
+        )
+
+
+class TestRootDatasetNoGCPs:
+    """Tests that root datasets (non-subdatasets) have no GCPs."""
+
+    @pytest.fixture
+    def dataset(self):
+        """Open GRD product at root level."""
+        gdal.UseExceptions()
+        ds = gdal.OpenEx(
+            f"EOPFZARR:'{GRD_URL}'",
+            gdal.OF_RASTER | gdal.OF_READONLY,
+            open_options=["GRD_MULTIBAND=NO"],
+        )
+        yield ds
+        if ds:
+            ds = None
+
+    def test_root_no_gcps(self, dataset):
+        """Root dataset should have no GCPs (only subdatasets have them)."""
+        assert dataset is not None
+        assert dataset.GetGCPCount() == 0
+
+
+class TestSLCBurstGCPs:
+    """Tests that SLC burst subdatasets also have GCPs."""
+
+    @pytest.fixture
+    def dataset(self):
+        """Open SLC burst via BURST option."""
+        gdal.UseExceptions()
+        ds = gdal.OpenEx(
+            f"EOPFZARR:'{SLC_URL}'",
+            gdal.OF_RASTER | gdal.OF_READONLY,
+            open_options=["BURST=IW1_VV_001"],
+        )
+        yield ds
+        if ds:
+            ds = None
+
+    def test_slc_burst_has_gcps(self, dataset):
+        """SLC burst should have GCPs."""
+        assert dataset is not None
+        count = dataset.GetGCPCount()
+        assert count > 0, "SLC burst should have GCPs"
+
+    def test_slc_burst_gcp_coordinates(self, dataset):
+        """SLC burst GCPs should have valid coordinates."""
+        assert dataset is not None
+        gcps = dataset.GetGCPs()
+        assert gcps is not None
+        for gcp in gcps:
+            assert -180.0 <= gcp.GCPX <= 180.0
+            assert -90.0 <= gcp.GCPY <= 90.0
+
+    def test_slc_burst_gcp_srs(self, dataset):
+        """SLC burst GCP SRS should be WGS84."""
+        assert dataset is not None
+        srs = dataset.GetGCPSpatialRef()
+        assert srs is not None
+        assert srs.IsGeographic()
+
+
+class TestGRDMultiBandNoGCPs:
+    """Tests that GRD multi-band wrapper doesn't expose GCPs (it's a VRT)."""
+
+    @pytest.fixture
+    def dataset(self):
+        """Open GRD product with multi-band mode (default)."""
+        gdal.UseExceptions()
+        ds = gdal.Open(f"EOPFZARR:'{GRD_URL}'")
+        yield ds
+        if ds:
+            ds = None
+
+    def test_multiband_gcp_count(self, dataset):
+        """Multi-band GRD wrapper may or may not have GCPs."""
+        assert dataset is not None
+        # The multi-band wrapper is a VRT — it doesn't have SUBDATASET_PATH
+        # so LoadGCPs should skip it. GCPCount should be 0.
+        assert dataset.GetGCPCount() == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Implements `LoadGCPs()` method in `EOPFZarrDataset` that reads `pixel`, `line`, `latitude`, `longitude`, and `height` arrays from `conditions/gcp/` groups in Sentinel-1 products
- GCPs are loaded lazily on first call to `GetGCPCount()`/`GetGCPs()`/`GetGCPSpatialRef()` — only for measurement subdatasets (not root datasets)
- GCP SRS is set to WGS84 (EPSG:4326)
- Verified on GRD (~294 GCPs per subdataset) and SLC burst (~210 GCPs per burst) products

## Files Changed
- `src/eopfzarr_dataset.h` — Added GCP member variables (`mGCPs`, `mGCPSRS`, `mGCPsLoaded`) and `LoadGCPs()` declaration
- `src/eopfzarr_dataset.cpp` — Implemented `LoadGCPs()`, updated `GetGCPCount()`/`GetGCPs()`/`GetGCPSpatialRef()` to call it, added GCP cleanup in destructor
- `tests/integration/test_gcp_extraction.py` — 12 integration tests

## Test plan
- [x] GRD subdataset has >100 GCPs with valid lat/lon/pixel/line ranges
- [x] GCPs form a regular grid (nLines x nPixels)
- [x] GCP SRS is WGS84
- [x] GCPs have unique IDs and valid heights
- [x] Root dataset has 0 GCPs (no SUBDATASET_PATH)
- [x] Multi-band GRD wrapper has 0 GCPs
- [x] SLC burst has GCPs with valid coordinates and WGS84 SRS
- [x] Full regression: 103 tests pass, 0 failures