### PR TITLE
ci: automate Docker Hub image rebuild on push to main

### DIFF
--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -1,0 +1,35 @@
+name: Publish JupyterHub Image to Docker Hub
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker-images/eopfzarr-jupyterhub
+          file: ./docker-images/eopfzarr-jupyterhub/Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/eopf-zarr-driver:latest
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-images/eopfzarr-jupyterhub/Dockerfile
+++ b/docker-images/eopfzarr-jupyterhub/Dockerfile
@@ -1,0 +1,24 @@
+FROM ghcr.io/eopf-sample-service/eopf-container-images/eopf-zarr-driver:latest
+
+USER root
+
+# Add rioxarray (missing from base image, tracked in eopf-container-images#46)
+RUN mamba install -y -c conda-forge rioxarray && mamba clean --all -f -y
+
+# Rebuild EOPF-Zarr driver from latest main to pick up newest changes
+RUN git clone --depth 1 https://github.com/EOPF-Sample-Service/GDAL-ZARR-EOPF.git /tmp/eopf-zarr && \
+    cd /tmp/eopf-zarr && \
+    mkdir build && cd build && \
+    export PATH="/opt/conda/bin:$PATH" && \
+    cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_PREFIX_PATH="/opt/conda" \
+        -DGDAL_INCLUDE_DIR="/opt/conda/include" \
+        -DGDAL_LIBRARY="/opt/conda/lib/libgdal.so" \
+        -DCMAKE_INSTALL_RPATH="/opt/conda/lib" \
+        -DCMAKE_BUILD_RPATH="/opt/conda/lib" && \
+    make -j$(nproc) && \
+    cp gdal_EOPFZarr.so /opt/conda/lib/gdalplugins/ && \
+    rm -rf /tmp/eopf-zarr
+
+USER $NB_UID


### PR DESCRIPTION
## Summary

- Adds `docker-images/eopfzarr-jupyterhub/Dockerfile` — JupyterHub-compatible image based on `eopf-container-images/eopf-zarr-driver`, with `rioxarray` added and the EOPF plugin rebuilt from latest `main`
- Adds `.github/workflows/dockerhub-publish.yml` — triggers on every push to `main`, builds and pushes to `yuvraj1989/eopf-zarr-driver:latest` on Docker Hub

## Notes

- Requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets (already added)
- Closes #197, supersedes #196