### PR TITLE
fix: recover coordinate-array geotransform when PAM is disabled at construction

### DIFF
--- a/src/eopfzarr_dataset.cpp
+++ b/src/eopfzarr_dataset.cpp
@@ -61,6 +61,12 @@ static bool LoadGCPsFromZarr(const std::string& rootPath,
     const char* arrayNames[] = {"pixel", "line", "latitude", "longitude", "height"};
     GDALDataset* gcpDS[5] = {nullptr};
 
+    // Suppress GDAL errors while probing — "Cannot find group conditions" is
+    // expected for non-Sentinel-1 products and must not leak to the caller.
+    // CPLQuietErrorHandler prevents display but GDAL still stores the error in
+    // thread-local state; CPLErrorReset() clears that so Python callers with
+    // UseExceptions() don't see a RuntimeError from the probe.
+    CPLPushErrorHandler(CPLQuietErrorHandler);
     for (int i = 0; i < 5; i++)
     {
         std::string zarrPath =
@@ -69,12 +75,16 @@ static bool LoadGCPsFromZarr(const std::string& rootPath,
             zarrPath.c_str(), GDAL_OF_RASTER | GDAL_OF_READONLY, nullptr, nullptr, nullptr));
         if (!gcpDS[i])
         {
+            CPLPopErrorHandler();
+            CPLErrorReset();
             CPLDebug("EOPFZARR", "LoadGCPsFromZarr: failed to open %s", zarrPath.c_str());
             for (int j = 0; j < i; j++)
                 GDALClose(gcpDS[j]);
             return false;
         }
     }
+    CPLPopErrorHandler();
+    CPLErrorReset();
 
     int nPixels = std::max(gcpDS[0]->GetRasterXSize(), gcpDS[0]->GetRasterYSize());
     int nLines = std::max(gcpDS[1]->GetRasterXSize(), gcpDS[1]->GetRasterYSize());

--- a/src/eopfzarr_dataset.cpp
+++ b/src/eopfzarr_dataset.cpp
@@ -836,6 +836,25 @@ CPLErr EOPFZarrDataset::GetGeoTransform(double* padfTransform)
     if (eErr == CE_None)
         return eErr;
 
+    // LoadGeoTransformFromCoordinateArrays() runs during construction while
+    // GDAL_PAM_ENABLED=NO (EOPFOpen's PamDisableGuard), so GDALPamDataset::
+    // SetGeoTransform() is a no-op there (psPam uninitialised).  The correctly
+    // half-pixel-adjusted value was stored in mCache — recover it here and
+    // re-persist it into PAM so subsequent calls take the fast path.
+    double cachedTransform[6];
+    if (const_cast<EOPFZarrDataset*>(this)->mCache.GetCachedGeoTransform(cachedTransform))
+    {
+#ifdef HAVE_GDAL_GEOTRANSFORM
+        const_cast<EOPFZarrDataset*>(this)->GDALPamDataset::SetGeoTransform(
+            GDALGeoTransform(cachedTransform));
+        padfTransform = GDALGeoTransform(cachedTransform);
+#else
+        const_cast<EOPFZarrDataset*>(this)->GDALPamDataset::SetGeoTransform(cachedTransform);
+        std::copy(cachedTransform, cachedTransform + 6, padfTransform);
+#endif
+        return CE_None;
+    }
+
     return mInner->GetGeoTransform(padfTransform);
 }
 


### PR DESCRIPTION
## Problem

`LoadGeoTransformFromCoordinateArrays()` runs during `EOPFZarrDataset` construction, which is nested inside `EOPFOpen`'s `PamDisableGuard` (`GDAL_PAM_ENABLED=NO`).

When PAM is disabled, `GDALPamDataset::PamInitialize()` skips allocating `psPam`, so the `SetGeoTransform()` call at the end of the function is silently dropped. The correctly half-pixel-adjusted origin (e.g. `300000` instead of `300005` for Sentinel-2 10m) was placed in `mCache` but `GetGeoTransform()` never consulted the cache — it went straight to `GDALPamDataset::GetGeoTransform()` (returns `CE_Failure`) then `mInner->GetGeoTransform()`.

On **Linux** (GDAL 3.11, UbuntuGIS) the inner ZARR driver applies the half-pixel offset itself, so the test passes accidentally. On **Windows** (OSGeo4W), the ZARR driver returns raw pixel-centre coordinates, causing `test_b02_10m_origin_and_pixel_size` to fail with origin `(300005, 4199995)` instead of `(300000, 4200000)`.

## Fix

After the PAM lookup fails in `GetGeoTransform()`, check `mCache.GetCachedGeoTransform()` and re-persist the value into PAM (PAM is now enabled since `EOPFOpen` has returned) so all subsequent calls take the normal fast path.

## Test plan
- [x] `test_b02_10m_origin_and_pixel_size` passes on Windows in integration tests
- [x] `test_b09_60m_origin_and_pixel_size` and `test_10m_and_60m_share_same_origin` also pass
- [x] Sentinel-1 GRD geolocation (GCPs) still works — `GetGeoTransform` still returns `CE_Failure` when GCPs present