### PR TITLE
fix(docker): pin sqlite in jupyterhub image and add build-time GDAL verification

### DIFF
--- a/docker-images/eopfzarr-jupyterhub/Dockerfile
+++ b/docker-images/eopfzarr-jupyterhub/Dockerfile
@@ -2,8 +2,16 @@ FROM ghcr.io/eopf-sample-service/eopf-container-images/eopf-zarr-driver:latest
 
 USER root
 
-# Add rioxarray (missing from base image, tracked in eopf-container-images#46)
-RUN mamba install -y -c conda-forge rioxarray && mamba clean --all -f -y
+# Add rioxarray (missing from base image, tracked in eopf-container-images#46).
+# Pin sqlite/libsqlite so the re-solve cannot downgrade them: an older `sqlite`
+# package overwrites libsqlite3.so.0 and breaks libgdal with
+# "undefined symbol: sqlite3_total_changes64" (needs sqlite >= 3.37).
+RUN mamba install -y -c conda-forge rioxarray 'sqlite>=3.45' 'libsqlite>=3.45' && \
+    mamba clean --all -f -y
+
+# Fail the build if the install left GDAL broken (catches sqlite/ABI mismatches)
+RUN gdalinfo --version && \
+    python -c "from osgeo import gdal; print('GDAL python OK:', gdal.__version__)"
 
 # Rebuild EOPF-Zarr driver from latest main to pick up newest changes
 RUN git clone --depth 1 https://github.com/EOPF-Sample-Service/GDAL-ZARR-EOPF.git /tmp/eopf-zarr && \
@@ -20,5 +28,8 @@ RUN git clone --depth 1 https://github.com/EOPF-Sample-Service/GDAL-ZARR-EOPF.gi
     make -j$(nproc) gdal_EOPFZarr && \
     cp gdal_EOPFZarr.so /opt/conda/lib/gdalplugins/ && \
     rm -rf /tmp/eopf-zarr
+
+# Fail the build if the EOPFZARR driver does not register
+RUN python -c "from osgeo import gdal; gdal.AllRegister(); d = gdal.GetDriverByName('EOPFZARR'); assert d, 'EOPFZARR driver failed to load'; print('EOPFZARR driver OK:', d.GetDescription())"
 
 USER $NB_UID


### PR DESCRIPTION
## Problem

The published `5.0` JupyterHub image was broken — every GDAL entry point crashed:

```
gdalinfo: symbol lookup error: /opt/conda/lib/libgdal.so.36:
          undefined symbol: sqlite3_total_changes64
```

Reported by @clausmichele in EOPF-Sample-Service/eopf-sample-notebooks#261 ("The new GDAL 5.0 image is broken").

## Root cause

The base image (`eopf-container-images/eopf-zarr-driver:latest`) ships a consistent env: GDAL 3.10.3 + sqlite/libsqlite 3.52.0. The `RUN mamba install rioxarray` layer re-solves that env and **downgraded `sqlite` to 3.32.3** while `libsqlite` moved to 3.53.x. The old `sqlite` package overwrote `libsqlite3.so.0`, which lacks `sqlite3_total_changes64` (added in SQLite 3.37), breaking `libgdal` — and with it the EOPFZARR driver, which never got a chance to load.

## Fix

- **Pin `sqlite>=3.45` and `libsqlite>=3.45`** in the rioxarray install so the solver can no longer take the downgrade path.
- **Build gate 1:** run `gdalinfo --version` + import the GDAL Python bindings right after the install — an ABI mismatch now fails the build instead of shipping.
- **Build gate 2:** assert the freshly compiled `EOPFZARR` driver registers.

## Verification

Built locally from this Dockerfile and verified in the container:

| Check | Broken 5.0 | This build |
|---|---|---|
| `gdalinfo --formats` | symbol lookup error | `EOPFZARR -raster- (rovs)` ✅ |
| `sqlite` / `libsqlite` | 3.32.3 / 3.53.3 (mismatch) | 3.52.0 / 3.52.0 ✅ |
| GDAL Python bindings | crash | `3.10.3` ✅ |

The fixed image has already been pushed over the `5.0`, `5.0.0`, and `latest` tags on Docker Hub (`yuvraj1989/eopf-zarr-driver`), so the JupyterHub spawner link in the notebook PR picks it up on next spawn. This PR makes sure CI does not republish a broken image on the next push to `main`.

## Note

The QGIS image is not affected: it uses a different base and a single atomic `mamba install` (no post-hoc re-solve), and already has equivalent build-time verification. Long-term, once rioxarray lands in the base image (eopf-container-images#46), the install layer and pin here can be dropped entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)